### PR TITLE
last verison i work on #106

### DIFF
--- a/civicsocialmedia/src/routes/begrijpen/+layout.server.js
+++ b/civicsocialmedia/src/routes/begrijpen/+layout.server.js
@@ -1,0 +1,13 @@
+
+export async function load({ fetch }) {
+  // Data from Directus API
+  const toolkitUrl = 'https://fdnd-agency.directus.app/items/Toolkit';
+  const fields = 'fields=id,title,subtitle,body';
+
+  //  data to json
+  const toolkitResponse = await fetch(`${toolkitUrl}?${fields}`);
+  const toolkitData = await toolkitResponse.json();
+  return {
+    toolkitItems: toolkitData.data ?? []
+  };
+}

--- a/civicsocialmedia/src/routes/begrijpen/step2/+page.svelte
+++ b/civicsocialmedia/src/routes/begrijpen/step2/+page.svelte
@@ -1,11 +1,32 @@
 <script>
-  import ProgressStepper from '$lib/components/ProgressStepper.svelte';
-  const steps = [
-    { href: '/begijpen/step1' },
-    { href: '/begijpen/step2' },
-    { href: '/begijpen/step3' },
-  ];
-  const current = 1; // we are on step 2
-</script>
+  import ProgressStepperV2 from '$lib/components/ProgressStepperV2.svelte';
+  export let data;
+  const toolkitItems = data.toolkitItems ?? [];
 
-<ProgressStepper {steps} {current} />
+  const currentStep = 2; // the current step number the user on it
+  const toolkitItem = toolkitItems.find(i => Number(i.id) === currentStep) ?? null;
+</script>
+<main>
+<ProgressStepperV2 {currentStep} />
+
+{#if toolkitItem}
+  <h1>1. {toolkitItem.title}</h1>
+  <p>{toolkitItem.subtitle}</p>
+{:else}
+  <p>Geen data gevonden voor deze stap.</p>
+{/if}
+
+  
+</main>
+
+<style>
+    main {
+        padding: 2em;
+    }
+
+    h1{
+        padding-left: .5em;
+    }
+    
+</style>
+

--- a/civicsocialmedia/src/routes/begrijpen/step3/+page.svelte
+++ b/civicsocialmedia/src/routes/begrijpen/step3/+page.svelte
@@ -1,11 +1,32 @@
 <script>
-  import ProgressStepper from '$lib/components/ProgressStepper.svelte';
-  const steps = [
-    { href: '/begijpen/step1' },
-    { href: '/begijpen/step2' },
-    { href: '/begijpen/step3' },
-  ];
-  const current = 2; 
-</script>
+  import ProgressStepperV2 from '$lib/components/ProgressStepperV2.svelte';
+  export let data;
+  const toolkitItems = data.toolkitItems ?? [];
 
-<ProgressStepper {steps} {current} />
+  const currentStep = 3; // the current step number the user on it
+  const toolkitItem = toolkitItems.find(i => Number(i.id) === currentStep) ?? null;
+</script>
+<main>
+<ProgressStepperV2 {currentStep} />
+
+{#if toolkitItem}
+  <h1>1. {toolkitItem.title}</h1>
+  <p>{toolkitItem.subtitle}</p>
+{:else}
+  <p>Geen data gevonden voor deze stap.</p>
+{/if}
+
+  
+</main>
+
+<style>
+    main {
+        padding: 2em;
+    }
+
+    h1{
+        padding-left: .5em;
+    }
+    
+</style>
+


### PR DESCRIPTION
## What does this change?

Resolves issue #106

This PR wires up the Toolkit flow so that steps 2 and 3 are driven by real data from the Directus API instead of being hardcoded.

## Key changes:
Added layout.server.js for Toolkit routes
Read from the layout data to show the correct title and subtitle for step 2.
Remove hardcoded content for this step.


## How Has This Been Tested?

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Video


https://github.com/user-attachments/assets/f531ff5e-3165-4e7b-928d-8993f74c88d4


## How to review

Start the dev server
Run the app locally as usual.
Check data loading for step 2 and step 3
Go to: /begijpen/step2 or /begijpen/step3

**Note:** You won’t see the ProgressStepperV2 yet because it’s part of another pull request. That will only be visible once both PRs are merged into dev.

Hey @Abeeryu @Karima002 Let me know if anything should be improved or adjusted. Looking for feedback on the data loading approach and how the step pages use the layout data.