### PR TITLE
194 overview page step 1 begrijpen

### DIFF
--- a/civicsocialmedia/src/routes/begrijpen/overzicht/+page.svelte
+++ b/civicsocialmedia/src/routes/begrijpen/overzicht/+page.svelte
@@ -1,8 +1,9 @@
 <main>
     <section>
         <h2>Overzicht van alle vragen</h2>
-        <button class="print">Printen</button>
     </section>
+    
+    <button class="print">Printen</button>
 
     <label>Stap 1
         <textarea readonly>Begin met een onderzoeksvraag. Welke gemeenschap wil je beter begrijpen? 
@@ -22,50 +23,80 @@
 
     <ul>
         <li>
-            <button>Bevestigen en verzenden</button>
+            <button class="send">Bevestigen en verzenden</button>
         </li>
 
         <li>
-            <button>Volgende activiteit: Ontwerpen</button>
+            <button class="send">Volgende activiteit: Ontwerpen</button>
         </li>
     </ul>
 </main>
 
 <style>
-    main {
-        padding: 1em;
-    }
+main {
+    padding: 2em;
+}
 
-    section {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        margin-bottom: 2em;
-    }
+section {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 2em;
+}
 
-    .print {
+.print {
+    all: unset;
+    position: fixed;
+    right: 2rem;
+    bottom: 2em;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1em 1.5em 1em 1.5em;
+    background-color: var(--primary-color-deep-blue);
+    color: var(--neutral-color-white);
+    height: 2vh;
+    width: 10em;
+    padding: 1em;
+    border-radius: 6em;
+    text-decoration: none;
+    transition: background .2s, transform .1s, box-shadow .2s;
+        &:hover {
+        background: #0d3749;
+        transform: translateY(-0.1rem);
+        box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, .25);
+        cursor: pointer;
+        }
         
+        &:focus-visible {
+        outline: 0.2rem solid var(--neutral-color-white);
+        outline-offset: 0.15rem;
+        }
+}
+
+h2 {
+    text-align: left;
+}
+    
+label {
+    font-weight: bold;
+    }
+
+textarea {
+    all: unset;
+    width: 80vw;      
+    max-width: 100vw; 
+    height: 6em;
+    border: 1px solid var(--neutral-color-black);
+    padding: 2em;
+    margin: 2em 0 2em 0;
+    @media (min-width: 768px) {
+        width: 90vw;
     }
     
-    h2 {
-        text-align: left;
-    }
-     
-    label {
-        margin-bottom: 1.5em;
-        font-weight: bold;
-     }
-    
-    textarea {
-        all: unset;
-        width: 100%;
-        height: 6em;
-        border: 1px solid var(--neutral-color-black);
-        padding: 2em;
-        
-    }
+}
 
-     ul {
-        list-style: none;
-    }
+ul {
+list-style: none;
+}
 </style>

--- a/civicsocialmedia/src/routes/begrijpen/overzicht/+page.svelte
+++ b/civicsocialmedia/src/routes/begrijpen/overzicht/+page.svelte
@@ -1,3 +1,13 @@
+<script>
+    import {onMount} from 'svelte'
+
+    onMount(() => {
+        document.querySelector('.print').addEventListener('click', () => {
+            window.print();
+        });
+    });
+</script>
+
 <main>
     <section>
         <h2>Overzicht van alle vragen</h2>

--- a/civicsocialmedia/src/routes/begrijpen/overzicht/+page.svelte
+++ b/civicsocialmedia/src/routes/begrijpen/overzicht/+page.svelte
@@ -1,0 +1,32 @@
+<main>
+    <section>
+        <h2>Overzicht van alle vragen</h2>
+        <button class="print">Printen</button>
+    </section>
+
+    <label>Stap 1
+        <textarea readonly>Begin met een onderzoeksvraag. Welke gemeenschap wil je beter begrijpen? 
+        </textarea>
+    </label>
+
+    <label>Stap 2
+        <textarea readonly>Verken de 6 community archetypes en de bijbehorende behoeften van communities en organisaties, daarna kies 1 of 2 archetypes die het beste passen bij jouw community en/ of organisatie.
+        </textarea>
+    </label>
+
+    <label>Stap 3
+        <textarea readonly>Welke behoeften van communities en organisaties herken je? Op welke manieren is jouw community en/of organisatie anders?
+            Welke aannames maak je over jouw community? Zijn er blinde vlekken? Hoe zou je daar achter kunnen komen?
+        </textarea>
+    </label>
+
+    <ul>
+        <li>
+            <button>Bevestigen en verzenden</button>
+        </li>
+
+        <li>
+            <button>Volgende activiteit: Ontwerpen</button>
+        </li>
+    </ul>
+</main>

--- a/civicsocialmedia/src/routes/begrijpen/overzicht/+page.svelte
+++ b/civicsocialmedia/src/routes/begrijpen/overzicht/+page.svelte
@@ -21,7 +21,7 @@
    
 
     <h3>Stap 2</h3>
-    <p>Verken de 6 community archetypes en de bijbehorende behoeften van communities en organisaties, daarna kies 1 of 2 archetypes die het beste passen bij jouw community en/ of organisatie.</p>
+    <p>Verken de 6 community archetypes en de bijbehorende behoeften van communities en organisaties, daarna kies 1 of 2 archetypes die het beste passen bij jouw community en/of organisatie.</p>
     <textarea readonly>Antwoord gebruiker</textarea>
 
     <h3>Stap 3</h3>
@@ -87,18 +87,17 @@ h2 {
     
 label {
     font-weight: bold;
-    }
+}
 
 textarea {
     all: unset;
-    width: 80vw;      
-    max-width: 100vw; 
+    width: 70vw;      
     height: 6em;
     border: 1px solid var(--neutral-color-black);
     padding: 2em;
     margin: 2em 0 2em 0;
     @media (min-width: 768px) {
-        width: 90vw;
+        width: 87vw;
     }
     
 }

--- a/civicsocialmedia/src/routes/begrijpen/overzicht/+page.svelte
+++ b/civicsocialmedia/src/routes/begrijpen/overzicht/+page.svelte
@@ -5,31 +5,28 @@
     
     <button class="print">Printen</button>
 
-    <label>Stap 1
-        <textarea readonly>Begin met een onderzoeksvraag. Welke gemeenschap wil je beter begrijpen? 
-        </textarea>
-    </label>
+    <h3>Stap 1</h3>
+    <p>Begin met een onderzoeksvraag. Welke gemeenschap wil je beter begrijpen?</p>
+    <textarea readonly>Antwoord gebruiker </textarea>
+   
 
-    <label>Stap 2
-        <textarea readonly>Verken de 6 community archetypes en de bijbehorende behoeften van communities en organisaties, daarna kies 1 of 2 archetypes die het beste passen bij jouw community en/ of organisatie.
-        </textarea>
-    </label>
+    <h3>Stap 2</h3>
+    <p>Verken de 6 community archetypes en de bijbehorende behoeften van communities en organisaties, daarna kies 1 of 2 archetypes die het beste passen bij jouw community en/ of organisatie.</p>
+    <textarea readonly>Antwoord gebruiker</textarea>
 
-    <label>Stap 3
-        <textarea readonly>Welke behoeften van communities en organisaties herken je? Op welke manieren is jouw community en/of organisatie anders?
-            Welke aannames maak je over jouw community? Zijn er blinde vlekken? Hoe zou je daar achter kunnen komen?
-        </textarea>
-    </label>
+    <h3>Stap 3</h3>
+    <p>Welke behoeften van communities en organisaties herken je?</p>
+    <textarea readonly>Antwoord gebruiker</textarea>
 
-    <ul>
-        <li>
-            <button class="send">Bevestigen en verzenden</button>
-        </li>
+    <p>Op welke manieren is jouw community en/of organisatie anders?</p>
+    <textarea readonly>Antwoord gebruiker</textarea>
 
-        <li>
-            <button class="send">Volgende activiteit: Ontwerpen</button>
-        </li>
-    </ul>
+    <p>Welke aannames maak je over jouw community? Zijn er blinde vlekken? Hoe zou je daar achter kunnen komen?</p>
+    <textarea readonly>Antwoord gebruiker</textarea>
+
+
+    <button class="send">Bevestigen en verzenden</button>
+
 </main>
 
 <style>
@@ -96,7 +93,24 @@ textarea {
     
 }
 
-ul {
-list-style: none;
+.send {
+    all: unset;
+    display: inline-flex;
+    align-items: center;
+    height: 2.3em;
+    padding: .5em 2em .5em 2em;
+    border-radius: 6em;
+    background: var(--primary-color-deep-blue);
+    color: var(--neutral-color-white);
+    text-decoration: none;
+    transition: background-color .2s, transform .1s, box-shadow .2s;
+    
+    &:hover {
+        background-color: #0d3749;
+        transform: translateY(-0.1rem);
+        box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, .25);
+        cursor: pointer;
+  }
+   
 }
 </style>

--- a/civicsocialmedia/src/routes/begrijpen/overzicht/+page.svelte
+++ b/civicsocialmedia/src/routes/begrijpen/overzicht/+page.svelte
@@ -17,22 +17,21 @@
 
     <h3>Stap 1</h3>
     <p>Begin met een onderzoeksvraag. Welke gemeenschap wil je beter begrijpen?</p>
-    <textarea readonly>Antwoord gebruiker </textarea>
+    <textarea readonly aria-label="answer-user">Antwoord gebruiker </textarea>
    
 
     <h3>Stap 2</h3>
     <p>Verken de 6 community archetypes en de bijbehorende behoeften van communities en organisaties, daarna kies 1 of 2 archetypes die het beste passen bij jouw community en/of organisatie.</p>
-    <textarea readonly>Antwoord gebruiker</textarea>
+    <textarea readonly aria-label="answer-user">Antwoord gebruiker</textarea>
 
     <h3>Stap 3</h3>
     <p>Welke behoeften van communities en organisaties herken je?</p>
-    <textarea readonly>Antwoord gebruiker</textarea>
-
+    <textarea readonly aria-label="answer-user">Antwoord gebruiker</textarea>
     <p>Op welke manieren is jouw community en/of organisatie anders?</p>
-    <textarea readonly>Antwoord gebruiker</textarea>
+    <textarea readonly aria-label="answer-user">Antwoord gebruiker</textarea>
 
     <p>Welke aannames maak je over jouw community? Zijn er blinde vlekken? Hoe zou je daar achter kunnen komen?</p>
-    <textarea readonly>Antwoord gebruiker</textarea>
+    <textarea readonly aria-label="answer-user">Antwoord gebruiker</textarea>
 
 
     <button class="send">Bevestigen en verzenden</button>
@@ -97,7 +96,7 @@ textarea {
     padding: 2em;
     margin: 2em 0 2em 0;
     @media (min-width: 768px) {
-        width: 87vw;
+        width: 85vw;
     }
     
 }

--- a/civicsocialmedia/src/routes/begrijpen/overzicht/+page.svelte
+++ b/civicsocialmedia/src/routes/begrijpen/overzicht/+page.svelte
@@ -30,3 +30,42 @@
         </li>
     </ul>
 </main>
+
+<style>
+    main {
+        padding: 1em;
+    }
+
+    section {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 2em;
+    }
+
+    .print {
+        
+    }
+    
+    h2 {
+        text-align: left;
+    }
+     
+    label {
+        margin-bottom: 1.5em;
+        font-weight: bold;
+     }
+    
+    textarea {
+        all: unset;
+        width: 100%;
+        height: 6em;
+        border: 1px solid var(--neutral-color-black);
+        padding: 2em;
+        
+    }
+
+     ul {
+        list-style: none;
+    }
+</style>


### PR DESCRIPTION
## What does this change?

Resolves issue #194 
I've made a beginning to the overview page where you can see an overview of the steps. I've also processed the feedback of the client (#192). We had to put the questions above the text-area.


## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [x] [Accessibility test]()
- [x] [Performance test]()
- [x] [Responsive Design test]()
- [ ] [Device test]()
- [x] [Browser test]()


## Performance test
<img width="755" height="560" alt="Scherm­afbeelding 2026-01-02 om 22 56 32" src="https://github.com/user-attachments/assets/d06975e9-300f-48d9-a0a4-0c3bb23855c5" />

## Accessibility test
<img width="749" height="649" alt="Scherm­afbeelding 2026-01-02 om 22 57 03" src="https://github.com/user-attachments/assets/d3bdec02-4705-44b6-a5d6-506a3291f223" />

## Browser test: example Safari

<img width="1470" height="956" alt="Scherm­afbeelding 2026-01-02 om 23 11 02" src="https://github.com/user-attachments/assets/82b7e667-503a-47f2-9065-56fa21ad9306" />


## Images

<img width="1470" height="830" alt="Scherm­afbeelding 2025-12-16 om 11 52 23" src="https://github.com/user-attachments/assets/ac7dfdf2-324f-407e-816b-865663312050" />

<img width="1467" height="758" alt="Scherm­afbeelding 2026-01-02 om 23 11 21" src="https://github.com/user-attachments/assets/c895738f-37ac-4604-a915-a6a42d9ed71a" />


## How to review
- Do you see any improvement for the overview page for example the design?
- Do you see any improvemnts for the placement of the print button?
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
